### PR TITLE
Reduced the delay time for the initial logo, wrote a test

### DIFF
--- a/crashstation.rb
+++ b/crashstation.rb
@@ -13,6 +13,16 @@ require 'date'
 module CrashStation
   extend self
 
+  #if argv[0] is test, run using the test data
+  #otherwise run using mame data
+  def make_gif_wrapper()
+    if (ARGV[0] == 'test') then
+      make_gif_cli_test()
+    else
+      make_gif_cli()
+    end
+  end
+
   def make_gif_cli(
     game_filename: "#{__dir__}/crash.gme",
     gif_filename: make_filename,
@@ -21,6 +31,24 @@ module CrashStation
     puts 'Running mame...'
     video_data = run_emulator(game_filename, **args)
 
+    puts 'Processing video data...'
+    gif = process_video_data(video_data)
+
+    puts 'Writing gif...'
+    gif.write gif_filename
+
+    puts "Wrote GIF to \"#{gif_filename}\"."
+    puts 'Done!'
+  end
+
+  def make_gif_cli_test(
+    test_filename: "#{__dir__}/fixtures/test-video-data.txt",
+    gif_filename: make_filename,
+    **args
+  )
+    puts 'Loading test video data...'
+    video_data = File.read test_filename
+    
     puts 'Processing video data...'
     gif = process_video_data(video_data)
 
@@ -45,9 +73,26 @@ module CrashStation
     raw_lines = video_data.lines
 
     Magick::ImageList.new.tap do |gif|
+      add_first_frame_to gif, raw_lines.shift(LINES_PER_FRAME)
       until raw_lines.length < LINES_PER_FRAME
         add_frame_to gif, raw_lines.shift(LINES_PER_FRAME)
       end
+    end
+  end
+
+  def add_first_frame_to(gif, frame) #Edit the delay for the first frame
+    frame.pop # remove the separator line
+    frame.pop # ignore the first frame delay
+    frame.pop # remove the other separator line
+
+    delay = 0.5 # Half-second delay for the first frame
+
+    gif.new_image(SCREEN_SIZE, SCREEN_SIZE)
+    gif.last.tap do |gif_frame|
+      pixels = raw_frame_to_pixels frame
+      gif_frame.store_pixels 0, 0, SCREEN_SIZE, SCREEN_SIZE, pixels
+      gif_frame.delay = delay * gif_frame.ticks_per_second
+      gif_frame.resize! SCREEN_SIZE * 6, SCREEN_SIZE * 6, Magick::PointFilter
     end
   end
 
@@ -105,4 +150,4 @@ module CrashStation
   end
 end
 
-CrashStation.make_gif_cli if __FILE__ == $PROGRAM_NAME
+CrashStation.make_gif_wrapper if __FILE__ == $PROGRAM_NAME


### PR DESCRIPTION
Fixes #1 
Added a hardcoded 0.5s duration for the first gif frame instead of using the mame output. 
Added a test. Run `ruby crashstation.rb test` to make a gif with the test frame data instead of using mame. `ruby crashstation.rb` should still work as normal, I think? Added a wrapper function to use argv for this.